### PR TITLE
Exclude floating windows from preset layout calculations

### DIFF
--- a/bin/orbit
+++ b/bin/orbit
@@ -1040,14 +1040,14 @@ cmd_preset_2() {
   total=$(preset_tiling_window_ids | awk 'END {print NR}')
   if [ "$total" -ge 3 ]; then
     # Focus the stack_side-most window (furthest from main).
-    while aerospace focus --boundaries-action fail "$stack_side" 2>/dev/null; do :; done
+    while aerospace focus --ignore-floating --boundaries-action fail "$stack_side" 2>/dev/null; do :; done
     # Wrap it with its main_side neighbor into a new container whose layout
     # is opposite to the top-level — i.e., the stack container.
     aerospace join-with "$main_side"
     # Pull each remaining non-main window into the container: step toward main
     # by focus, then push the window back toward stack_side. Stop once focus
     # reaches the main window.
-    while aerospace focus --boundaries-action fail "$main_side" 2>/dev/null; do
+    while aerospace focus --ignore-floating --boundaries-action fail "$main_side" 2>/dev/null; do
       current_id=$(aerospace list-windows --focused --format '%{window-id}')
       [ "$current_id" = "$main_id" ] && break
       aerospace move "$stack_side"
@@ -1106,11 +1106,11 @@ cmd_preset_3() {
   # one window. A single-window slot is already its own top-level entry, and
   # `join-with` would fold it into a neighbor — collapsing 3 slots into 2.
   if [ "$outer_count" -ge 2 ]; then
-    while aerospace focus --boundaries-action fail "$stack_side" 2>/dev/null; do :; done
+    while aerospace focus --ignore-floating --boundaries-action fail "$stack_side" 2>/dev/null; do :; done
     aerospace join-with "$main_side"
     pulled=2
     while [ "$pulled" -lt "$outer_count" ]; do
-      aerospace focus --boundaries-action fail "$main_side" 2>/dev/null || break
+      aerospace focus --ignore-floating --boundaries-action fail "$main_side" 2>/dev/null || break
       aerospace move "$stack_side"
       pulled=$((pulled + 1))
     done
@@ -1120,13 +1120,13 @@ cmd_preset_3() {
     aerospace focus --window-id "$main_id"
     i=0
     while [ "$i" -lt "$inner_count" ]; do
-      aerospace focus --boundaries-action fail "$stack_side" 2>/dev/null || break
+      aerospace focus --ignore-floating --boundaries-action fail "$stack_side" 2>/dev/null || break
       i=$((i + 1))
     done
     aerospace join-with "$main_side"
     pulled=2
     while [ "$pulled" -lt "$inner_count" ]; do
-      aerospace focus --boundaries-action fail "$main_side" 2>/dev/null || break
+      aerospace focus --ignore-floating --boundaries-action fail "$main_side" 2>/dev/null || break
       current_id=$(aerospace list-windows --focused --format '%{window-id}')
       [ "$current_id" = "$main_id" ] && break
       aerospace move "$stack_side"

--- a/bin/orbit
+++ b/bin/orbit
@@ -966,12 +966,24 @@ preset_saved_window_hash() {
   sed -n '5p' "$file"
 }
 
+preset_tiling_window_ids() {
+  # Window-ids of the tiling (non-floating) windows on the focused workspace.
+  # Floating windows live outside the tiling tree — they don't get hit by
+  # `flatten-workspace-tree`, focus dfs walks skip them, and `balance-sizes`
+  # doesn't touch them — so any preset calculation that counts them ends up
+  # off by however many floats are around.
+  aerospace list-windows --workspace focused \
+    --format '%{window-id} %{window-parent-container-layout}' 2>/dev/null |
+    awk '$2 != "floating" {print $1}'
+}
+
 preset_window_hash() {
   # Sort to keep the hash stable across any ordering quirks in
   # `list-windows` output — only the *set* of windows on the workspace
-  # should affect the hash, not the order they're reported.
-  aerospace list-windows --workspace focused --format '%{window-id}' 2>/dev/null |
-    sort | shasum | awk '{print $1}'
+  # should affect the hash, not the order they're reported. Floating
+  # windows are excluded so toggling a sidebar in/out of float doesn't
+  # reset the cycle.
+  preset_tiling_window_ids | sort | shasum | awk '{print $1}'
 }
 
 preset_cycle_next() {
@@ -1022,8 +1034,10 @@ cmd_preset_2() {
 
   # Build the nested stack container by navigating with focus/move rather than
   # trusting list-windows to return tree order. Skip if there are fewer than
-  # two non-main windows (nothing to stack).
-  total=$(aerospace list-windows --workspace focused --count)
+  # two non-main windows (nothing to stack). Floating windows are excluded
+  # from the count — they're not in the tiling tree, so they wouldn't be
+  # reachable by the focus/move walk below anyway.
+  total=$(preset_tiling_window_ids | awk 'END {print NR}')
   if [ "$total" -ge 3 ]; then
     # Focus the stack_side-most window (furthest from main).
     while aerospace focus --boundaries-action fail "$stack_side" 2>/dev/null; do :; done
@@ -1077,7 +1091,10 @@ cmd_preset_3() {
   # Push main to the chosen edge of the top-level container.
   while aerospace move --boundaries-action fail "$main_side" 2>/dev/null; do :; done
 
-  total=$(aerospace list-windows --workspace focused --count)
+  # Floating windows are excluded — they're not in the tiling tree, so
+  # counting them here would skew the outer/inner split below and leave
+  # the stack containers with the wrong number of slots.
+  total=$(preset_tiling_window_ids | awk 'END {print NR}')
   non_main=$((total - 1))
   # Split the non-main windows between two stack-side slots. The
   # stack_side-most (outer) slot gets ceil(non_main / 2); the inner slot


### PR DESCRIPTION
## Summary
This change fixes preset layout calculations to exclude floating windows, which exist outside the tiling tree and were causing incorrect window counts and hash calculations.

## Key Changes
- **New function `preset_tiling_window_ids()`**: Extracts window IDs for only non-floating (tiling) windows on the focused workspace, with detailed comments explaining why floating windows must be excluded
- **Updated `preset_window_hash()`**: Now uses `preset_tiling_window_ids()` instead of all windows, so toggling a sidebar in/out of float doesn't reset the layout cycle
- **Fixed window counting in `cmd_preset_2()`**: Replaced `aerospace list-windows --count` with `preset_tiling_window_ids | awk 'END {print NR}'` to get accurate tiling window count for stack validation
- **Fixed window counting in `cmd_preset_3()`**: Same fix as above to ensure correct outer/inner split calculations for stack containers

## Implementation Details
Floating windows are problematic for preset calculations because they:
- Don't participate in the tiling tree (not hit by `flatten-workspace-tree`)
- Are skipped by focus DFS walks
- Aren't affected by `balance-sizes`
- Cause off-by-one errors when counted alongside tiling windows

The solution centralizes the logic for identifying tiling windows in a single reusable function that filters by checking the `window-parent-container-layout` field.

https://claude.ai/code/session_016BmaqAZPabJcPCKitkyDwW